### PR TITLE
Replace file tree with @pierre/trees

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
         "@openai/codex-sdk": "^0.125.0",
+        "@pierre/trees": "^1.0.0-beta.3",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -535,6 +536,8 @@
     "@openai/codex-win32-x64": ["@openai/codex@0.125.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.3", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1843,6 +1846,10 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
     "@openai/codex-sdk": "^0.125.0",
+    "@pierre/trees": "^1.0.0-beta.3",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/src/main/ipc/register-workspace-handlers.ts
+++ b/src/main/ipc/register-workspace-handlers.ts
@@ -40,6 +40,9 @@ import {
   type WorkspaceOpenInEditorInput,
   workspaceOpenInEditorInputSchema,
   workspaceOpenInEditorResultSchema,
+  type WorkspaceListAllPathsInput,
+  workspaceListAllPathsInputSchema,
+  workspaceListAllPathsResultSchema,
   type WorkspaceUpdateBaseRefInput,
   workspaceUpdateBaseRefInputSchema,
   workspaceUpdateBaseRefResultSchema
@@ -67,6 +70,13 @@ export function registerWorkspaceHandlers(
 ): void {
   const externalEditorService = createExternalEditorService({
     openPath: (targetPath) => shell.openPath(targetPath)
+  });
+
+  handleValidatedIpc(workspaceChannels.listAllPaths, {
+    handler: async (_event: IpcMainInvokeEvent, input: WorkspaceListAllPathsInput) =>
+      workspaceService.listAllPaths(input.taskId),
+    inputSchema: workspaceListAllPathsInputSchema,
+    outputSchema: workspaceListAllPathsResultSchema
   });
 
   handleValidatedIpc(workspaceChannels.listDirectory, {

--- a/src/main/services/workspace-service.ts
+++ b/src/main/services/workspace-service.ts
@@ -61,6 +61,31 @@ export function createWorkspaceService(
   const { taskWorkspaceRepository } = workspaceRuntime;
 
   return {
+    async listAllPaths(taskId: number): Promise<{ paths: string[] }> {
+      const context = await workspaceRuntime.resolveWorkspaceContext(taskId);
+      const paths: string[] = [];
+      const MAX_PATHS = 10_000;
+
+      async function walk(dir: string, prefix: string) {
+        if (paths.length >= MAX_PATHS) return;
+        const entries = await readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (paths.length >= MAX_PATHS) return;
+          if (entry.name === '.git' || entry.name === 'node_modules') continue;
+          const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+          if (entry.isDirectory()) {
+            paths.push(`${rel}/`);
+            await walk(`${dir}/${entry.name}`, rel);
+          } else {
+            paths.push(rel);
+          }
+        }
+      }
+
+      await walk(context.worktreePath, '');
+      return { paths };
+    },
+
     async listDirectory(input: WorkspaceDirectoryInput): Promise<WorkspaceDirectorySnapshot> {
       const context = await workspaceRuntime.resolveWorkspaceContext(input.taskId);
       const relativePath = normalizeRelativePath(input.relativePath ?? '');

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,8 @@ import {
   resizeAgentSessionResultSchema,
   sendAgentSessionInputSchema,
   sendAgentSessionResultSchema,
+  setSystemPromptInputSchema,
+  setSystemPromptResultSchema,
   startAgentSessionInputSchema,
   startAgentSessionResultSchema,
   stopAgentSessionInputSchema,
@@ -48,6 +50,8 @@ import {
   workspaceDiffResultSchema,
   workspaceDirectoryInputSchema,
   workspaceDirectoryResultSchema,
+  workspaceListAllPathsInputSchema,
+  workspaceListAllPathsResultSchema,
   workspaceIntegrateBaseInputSchema,
   workspaceIntegrationResultSchema,
   workspaceListBranchesInputSchema,
@@ -112,6 +116,12 @@ const api: AutocodeApi = {
         input,
         inputSchema: resizeAgentSessionInputSchema,
         outputSchema: resizeAgentSessionResultSchema
+      }),
+    setSystemPrompt: (input) =>
+      invokeValidatedIpc(agentSessionChannels.setSystemPrompt, {
+        input,
+        inputSchema: setSystemPromptInputSchema,
+        outputSchema: setSystemPromptResultSchema
       }),
     sendInput: (input) =>
       invokeValidatedIpc(agentSessionChannels.sendInput, {
@@ -189,6 +199,12 @@ const api: AutocodeApi = {
       })
   },
   workspaces: {
+    listAllPaths: (input) =>
+      invokeValidatedIpc(workspaceChannels.listAllPaths, {
+        input,
+        inputSchema: workspaceListAllPathsInputSchema,
+        outputSchema: workspaceListAllPathsResultSchema
+      }),
     listDirectory: (input) =>
       invokeValidatedIpc(workspaceChannels.listDirectory, {
         input,

--- a/src/renderer/src/features/workspace/workspace-file-explorer.tsx
+++ b/src/renderer/src/features/workspace/workspace-file-explorer.tsx
@@ -1,279 +1,69 @@
-import { memo, useMemo } from 'react';
-import clsx from 'clsx';
-import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
+import { FileTree, useFileTree, useFileTreeSelection } from '@pierre/trees/react';
 
-import { FileTypeIcon } from '../../lib/file-type-icon';
-import { useWorkspaceExplorerDirectoryQuery } from './workspace-hooks';
+import { useWorkspaceAllPathsQuery } from './workspace-hooks';
 
 interface WorkspaceFileExplorerProps {
-  expandedDirectories: string[];
   onSelectPath: (path: string) => void;
-  onToggleDirectory: (path: string) => void;
   selectedPath: string | null;
   taskId: number;
 }
 
 export function WorkspaceFileExplorer({
-  expandedDirectories,
   onSelectPath,
-  onToggleDirectory,
   selectedPath,
   taskId
 }: WorkspaceFileExplorerProps) {
-  const rootDirectoryQuery = useWorkspaceExplorerDirectoryQuery(taskId, '');
-  const expandedDirectorySet = useMemo(
-    () => new Set(expandedDirectories),
-    [expandedDirectories]
-  );
+  const allPathsQuery = useWorkspaceAllPathsQuery(taskId);
+  const paths = allPathsQuery.data?.paths ?? [];
 
-  return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <div className="min-h-0 flex-1 overflow-auto py-1">
-        {rootDirectoryQuery.isLoading ? (
-          <ExplorerMessage>
-            <Loader2 className="mr-1.5 inline h-3 w-3 animate-spin" />
-            Loading files
-          </ExplorerMessage>
-        ) : null}
-
-        {rootDirectoryQuery.error ? (
-          <ExplorerMessage tone="error">{formatError(rootDirectoryQuery.error)}</ExplorerMessage>
-        ) : null}
-
-        {rootDirectoryQuery.data ? (
-          <ul>
-            {rootDirectoryQuery.data.entries.map((entry) => (
-              <WorkspaceFileTreeNode
-                key={entry.relativePath}
-                depth={0}
-                expandedDirectorySet={expandedDirectorySet}
-                entry={entry}
-                onSelectPath={onSelectPath}
-                onToggleDirectory={onToggleDirectory}
-                selectedPath={selectedPath}
-                taskId={taskId}
-              />
-            ))}
-          </ul>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-interface WorkspaceFileTreeNodeProps {
-  depth: number;
-  expandedDirectorySet: ReadonlySet<string>;
-  entry: WorkspaceFileTreeEntry;
-  onSelectPath: (path: string) => void;
-  onToggleDirectory: (path: string) => void;
-  selectedPath: string | null;
-  taskId: number;
-}
-
-type WorkspaceFileTreeEntry =
-  | {
-      kind: 'directory';
-      name: string;
-      relativePath: string;
+  const { model } = useFileTree({
+    flattenEmptyDirectories: true,
+    initialExpansion: 1,
+    paths,
+    onSelectionChange: (selectedPaths) => {
+      const selected = selectedPaths[0];
+      if (selected && !selected.endsWith('/')) {
+        onSelectPath(selected);
+      }
     }
-  | {
-      kind: 'file';
-      name: string;
-      relativePath: string;
-    };
+  });
 
-function WorkspaceFileTreeNode({
-  depth,
-  expandedDirectorySet,
-  entry,
-  onSelectPath,
-  onToggleDirectory,
-  selectedPath,
-  taskId
-}: WorkspaceFileTreeNodeProps) {
-  if (entry.kind === 'directory') {
+  const modelRef = useRef(model);
+  modelRef.current = model;
+
+  useEffect(() => {
+    if (selectedPath) {
+      model.focusPath(selectedPath);
+    }
+  }, [selectedPath, model]);
+
+  if (allPathsQuery.isLoading) {
     return (
-      <WorkspaceDirectoryTreeNode
-        depth={depth}
-        entry={entry}
-        expandedDirectorySet={expandedDirectorySet}
-        onSelectPath={onSelectPath}
-        onToggleDirectory={onToggleDirectory}
-        selectedPath={selectedPath}
-        taskId={taskId}
-      />
+      <div className="flex items-center gap-2 px-3 py-4 text-[12px] text-white/40">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading files
+      </div>
+    );
+  }
+
+  if (allPathsQuery.error) {
+    return (
+      <div className="px-3 py-4 text-[12px] text-rose-300">
+        {allPathsQuery.error instanceof Error
+          ? allPathsQuery.error.message
+          : 'Could not load file tree.'}
+      </div>
     );
   }
 
   return (
-    <WorkspaceFileLeafNode
-      depth={depth}
-      entry={entry}
-      onSelectPath={onSelectPath}
-      selectedPath={selectedPath}
-    />
-  );
-}
-
-function WorkspaceDirectoryTreeNode({
-  depth,
-  entry,
-  expandedDirectorySet,
-  onSelectPath,
-  onToggleDirectory,
-  selectedPath,
-  taskId
-}: WorkspaceFileTreeNodeProps & { entry: WorkspaceFileTreeEntry & { kind: 'directory' } }) {
-  const isExpanded = expandedDirectorySet.has(entry.relativePath);
-  const childrenQuery = useWorkspaceExplorerDirectoryQuery(taskId, entry.relativePath, isExpanded);
-  const isSelected = entry.relativePath === selectedPath;
-  const paddingLeft = 10 + depth * 16;
-
-  return (
-    <li>
-      <WorkspaceTreeButton
-        depth={depth}
-        icon={isExpanded ? (
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-white/40" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-white/40" />
-        )}
-        isSelected={isSelected}
-        label={entry.name}
-        labelClassName="font-medium"
-        onMouseDown={(event) => {
-          event.preventDefault();
-          onToggleDirectory(entry.relativePath);
-        }}
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <FileTree
+        model={model}
+        style={{ height: '100%' }}
       />
-
-      {isExpanded ? (
-        <div>
-          {childrenQuery.isLoading ? (
-            <ExplorerMessage paddingLeft={paddingLeft + 22} size="sm">
-              <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />
-              Loading
-            </ExplorerMessage>
-          ) : null}
-
-          {childrenQuery.error ? (
-            <ExplorerMessage paddingLeft={paddingLeft + 22} size="sm" tone="error">
-              {formatError(childrenQuery.error)}
-            </ExplorerMessage>
-          ) : null}
-
-          {childrenQuery.data ? (
-            <ul>
-              {childrenQuery.data.entries.map((childEntry) => (
-                <WorkspaceFileTreeNode
-                  key={childEntry.relativePath}
-                  depth={depth + 1}
-                  expandedDirectorySet={expandedDirectorySet}
-                  entry={childEntry}
-                  onSelectPath={onSelectPath}
-                  onToggleDirectory={onToggleDirectory}
-                  selectedPath={selectedPath}
-                  taskId={taskId}
-                />
-              ))}
-            </ul>
-          ) : null}
-        </div>
-      ) : null}
-    </li>
+    </div>
   );
-}
-
-const WorkspaceFileLeafNode = memo(function WorkspaceFileLeafNode({
-  depth,
-  entry,
-  onSelectPath,
-  selectedPath
-}: {
-  depth: number;
-  entry: WorkspaceFileTreeEntry & { kind: 'file' };
-  onSelectPath: (path: string) => void;
-  selectedPath: string | null;
-}) {
-  const isSelected = entry.relativePath === selectedPath;
-
-  return (
-    <li>
-      <WorkspaceTreeButton
-        depth={depth}
-        icon={<FileTypeIcon filename={entry.name} />}
-        isSelected={isSelected}
-        label={entry.name}
-        onMouseDown={(event) => {
-          event.preventDefault();
-          onSelectPath(entry.relativePath);
-        }}
-      />
-    </li>
-  );
-});
-
-function WorkspaceTreeButton({
-  depth,
-  icon,
-  isSelected,
-  label,
-  labelClassName,
-  onMouseDown
-}: {
-  depth: number;
-  icon: React.ReactNode;
-  isSelected: boolean;
-  label: string;
-  labelClassName?: string;
-  onMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void;
-}) {
-  return (
-    <button
-      className={clsx(
-        'flex w-full items-center gap-2 py-[5px] pr-3 text-left font-geist text-[13px] leading-tight transition',
-        isSelected
-          ? 'bg-white/[0.08] text-white'
-          : labelClassName
-            ? 'text-white/80 hover:bg-white/[0.05] hover:text-white/90'
-            : 'text-white/60 hover:bg-white/[0.05] hover:text-white/80'
-      )}
-      onMouseDown={onMouseDown}
-      style={{ paddingLeft: 10 + depth * 16 }}
-      type="button"
-    >
-      {icon}
-      <span className={clsx(labelClassName, !labelClassName && 'font-normal')}>{label}</span>
-    </button>
-  );
-}
-
-function ExplorerMessage({
-  children,
-  paddingLeft = 12,
-  size = 'default',
-  tone = 'subtle'
-}: {
-  children: React.ReactNode;
-  paddingLeft?: number;
-  size?: 'default' | 'sm';
-  tone?: 'error' | 'subtle';
-}) {
-  return (
-    <p
-      className={clsx(
-        'py-1.5 font-geist',
-        size === 'sm' ? 'text-[11px]' : 'text-[12px]',
-        tone === 'error' ? 'text-rose-300' : 'text-white/40'
-      )}
-      style={{ paddingLeft }}
-    >
-      {children}
-    </p>
-  );
-}
-
-function formatError(error: unknown): string {
-  return error instanceof Error ? error.message : 'Autocode could not read this directory.';
 }

--- a/src/renderer/src/features/workspace/workspace-hooks.ts
+++ b/src/renderer/src/features/workspace/workspace-hooks.ts
@@ -28,6 +28,17 @@ import {
 
 const WORKSPACE_EXPLORER_DIRECTORY_STALE_TIME_MS = 60_000;
 const WORKSPACE_EXPLORER_DIRECTORY_GC_TIME_MS = 10 * 60_000;
+const WORKSPACE_ALL_PATHS_STALE_TIME_MS = 30_000;
+
+export function useWorkspaceAllPathsQuery(taskId: number | null) {
+  return useQuery({
+    enabled: taskId !== null,
+    queryKey: taskId !== null ? ['workspace', taskId, 'allPaths'] : ['workspace', 'idle', 'allPaths'],
+    queryFn: () => autocodeApi.workspaces.listAllPaths({ taskId: taskId! }),
+    staleTime: WORKSPACE_ALL_PATHS_STALE_TIME_MS,
+    refetchOnWindowFocus: false
+  });
+}
 
 export function useWorkspaceExplorerDirectoryQuery(
   taskId: number | null,

--- a/src/renderer/src/features/workspace/workspace-inspector-sidebar.tsx
+++ b/src/renderer/src/features/workspace/workspace-inspector-sidebar.tsx
@@ -25,7 +25,6 @@ interface WorkspaceInspectorSidebarProps {
   commitMessage: string;
   commitNotice: string | null;
   commits: WorkspaceCommitLogEntry[];
-  expandedDirectories: string[];
   isCommitting: boolean;
   isLoadingChanges: boolean;
   isLoadingCommits: boolean;
@@ -43,7 +42,6 @@ interface WorkspaceInspectorSidebarProps {
   onSelectChange: (path: string) => void;
   onSelectFile: (path: string) => void;
   onSelectSidebarTab: (tab: 'changes' | 'files') => void;
-  onToggleDirectory: (directoryPath: string) => void;
   reviewStatus: WorkspaceReviewStatus | null;
   publishStatusErrorMessage: string | null;
   selectedPath: string | null;
@@ -59,7 +57,6 @@ export function WorkspaceInspectorSidebar({
   commitNotice,
   commits,
   commitsLoadErrorMessage,
-  expandedDirectories,
   isCommitting,
   isLoadingChanges,
   isLoadingCommits,
@@ -76,7 +73,6 @@ export function WorkspaceInspectorSidebar({
   onSelectChange,
   onSelectFile,
   onSelectSidebarTab,
-  onToggleDirectory,
   reviewStatus,
   publishStatusErrorMessage,
   selectedPath,
@@ -115,8 +111,6 @@ export function WorkspaceInspectorSidebar({
       <div className="min-h-0 flex-1 overflow-hidden">
         {activeSidebarTab === 'files' ? (
           <WorkspaceFileExplorer
-            expandedDirectories={expandedDirectories}
-            onToggleDirectory={onToggleDirectory}
             onSelectPath={onSelectFile}
             selectedPath={selectedPath}
             taskId={taskId}

--- a/src/renderer/src/features/workspace/workspace-inspector.tsx
+++ b/src/renderer/src/features/workspace/workspace-inspector.tsx
@@ -109,7 +109,6 @@ function WorkspaceInspector({ onRequestTaskSelection, taskWorkspace }: Workspace
             commitNotice={fileController.commitNotice}
             commits={fileController.commits}
             commitsLoadErrorMessage={fileController.commitsLoadErrorMessage}
-            expandedDirectories={fileController.expandedDirectories}
             isCommitting={fileController.commitMutation.isPending}
             isLoadingChanges={fileController.isLoadingChanges}
             isLoadingCommits={fileController.isLoadingCommits}
@@ -126,7 +125,6 @@ function WorkspaceInspector({ onRequestTaskSelection, taskWorkspace }: Workspace
             onSelectChange={handleSelectChange}
             onSelectFile={handleSelectFile}
             onSelectSidebarTab={fileController.setActiveSidebarTab}
-            onToggleDirectory={fileController.toggleDirectory}
             reviewStatus={fileController.reviewStatus}
             publishStatusErrorMessage={fileController.publishStatusErrorMessage}
             selectedPath={fileController.selectedPath}

--- a/src/renderer/src/lib/autocode-api.ts
+++ b/src/renderer/src/lib/autocode-api.ts
@@ -26,6 +26,7 @@ export const autocodeApi: AutocodeApi = {
     rename: (input) => getAutocodeApi().agentSessions.rename(input),
     resize: (input) => getAutocodeApi().agentSessions.resize(input),
     sendInput: (input) => getAutocodeApi().agentSessions.sendInput(input),
+    setSystemPrompt: (input) => getAutocodeApi().agentSessions.setSystemPrompt(input),
     start: (input) => getAutocodeApi().agentSessions.start(input),
     stop: (input) => getAutocodeApi().agentSessions.stop(input),
     subscribe: (taskId, callback) => getAutocodeApi().agentSessions.subscribe(taskId, callback)
@@ -42,6 +43,7 @@ export const autocodeApi: AutocodeApi = {
     delete: (input) => getAutocodeApi().tasks.delete(input)
   },
   workspaces: {
+    listAllPaths: (input) => getAutocodeApi().workspaces.listAllPaths(input),
     listDirectory: (input) => getAutocodeApi().workspaces.listDirectory(input),
     listChanges: (input) => getAutocodeApi().workspaces.listChanges(input),
     listRecentCommits: (input) => getAutocodeApi().workspaces.listRecentCommits(input),

--- a/src/shared/contracts/electron-api.ts
+++ b/src/shared/contracts/electron-api.ts
@@ -8,6 +8,7 @@ import type {
   RenameAgentSessionInput,
   ResizeAgentSessionInput,
   SendAgentSessionInput,
+  SetSystemPromptInput,
   StartAgentSessionInput,
   StartAgentSessionResult,
   StopAgentSessionInput
@@ -36,6 +37,8 @@ import type {
   WorkspaceDiffResult,
   WorkspaceDirectoryInput,
   WorkspaceDirectoryResult,
+  WorkspaceListAllPathsInput,
+  WorkspaceListAllPathsResult,
   WorkspaceIntegrateBaseInput,
   WorkspaceIntegrationResult,
   WorkspaceListBranchesInput,
@@ -74,6 +77,7 @@ export interface AutocodeApi {
     rename: (input: RenameAgentSessionInput) => Promise<AgentSession>;
     resize: (input: ResizeAgentSessionInput) => Promise<void>;
     sendInput: (input: SendAgentSessionInput) => Promise<void>;
+    setSystemPrompt: (input: SetSystemPromptInput) => Promise<AgentSession>;
     start: (input: StartAgentSessionInput) => Promise<StartAgentSessionResult>;
     stop: (input: StopAgentSessionInput) => Promise<void>;
     subscribe: (
@@ -93,6 +97,7 @@ export interface AutocodeApi {
     delete: (input: DeleteTaskInput) => Promise<DeleteTaskResult>;
   };
   workspaces: {
+    listAllPaths: (input: WorkspaceListAllPathsInput) => Promise<WorkspaceListAllPathsResult>;
     listDirectory: (input: WorkspaceDirectoryInput) => Promise<WorkspaceDirectoryResult>;
     listChanges: (input: WorkspaceChangesInput) => Promise<WorkspaceChangesResult>;
     listRecentCommits: (input: WorkspaceRecentCommitsInput) => Promise<WorkspaceRecentCommitsResult>;

--- a/src/shared/contracts/workspaces.ts
+++ b/src/shared/contracts/workspaces.ts
@@ -15,6 +15,14 @@ import {
 
 const taskIdSchema = z.number().int().positive();
 
+export const workspaceListAllPathsInputSchema = z.object({
+  taskId: taskIdSchema
+});
+
+export const workspaceListAllPathsResultSchema = z.object({
+  paths: z.array(z.string())
+});
+
 export const workspaceDirectoryInputSchema = z.object({
   relativePath: z.string().optional().default(''),
   taskId: taskIdSchema
@@ -119,6 +127,8 @@ export const workspaceIntegrationResultSchema = z.object({
   message: z.string().min(1)
 });
 
+export type WorkspaceListAllPathsInput = z.infer<typeof workspaceListAllPathsInputSchema>;
+export type WorkspaceListAllPathsResult = z.infer<typeof workspaceListAllPathsResultSchema>;
 export type WorkspaceDirectoryInput = z.infer<typeof workspaceDirectoryInputSchema>;
 export type WorkspaceChangesInput = z.infer<typeof workspaceChangesInputSchema>;
 export type WorkspaceRecentCommitsInput = z.infer<typeof workspaceRecentCommitsInputSchema>;

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -6,6 +6,7 @@ export const agentSessionChannels = {
   rename: 'agentSessions:rename',
   resize: 'agentSessions:resize',
   sendInput: 'agentSessions:sendInput',
+  setSystemPrompt: 'agentSessions:setSystemPrompt',
   start: 'agentSessions:start',
   stop: 'agentSessions:stop'
 } as const;
@@ -36,6 +37,7 @@ export const workspaceChannels = {
   readFile: 'workspaces:readFile',
   listChanges: 'workspaces:listChanges',
   listRecentCommits: 'workspaces:listRecentCommits',
+  listAllPaths: 'workspaces:listAllPaths',
   listDirectory: 'workspaces:listDirectory',
   mergeTask: 'workspaces:mergeTask',
   pushBranch: 'workspaces:pushBranch',


### PR DESCRIPTION
## Summary
- Adds `@pierre/trees` package for the workspace file explorer
- Introduces a recursive `listAllPaths` IPC endpoint that walks the workspace (excluding `.git` and `node_modules`, capped at 10k paths)
- Rewrites `WorkspaceFileExplorer` to use `@pierre/trees/react`, replacing the manual lazy-loading tree with a virtualized, searchable component with directory flattening and keyboard navigation

## Test plan
- [ ] Open a workspace with files and verify the file tree renders
- [ ] Click a file and confirm it opens in the editor pane
- [ ] Verify search works (built-in to @pierre/trees)
- [ ] Verify empty directories are flattened (e.g. `src/utils/` shown inline)
- [ ] Test with a large workspace to confirm performance is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)